### PR TITLE
changes to not add avsrun to startup if offline demo is already added

### DIFF
--- a/tools/Install/setup.sh
+++ b/tools/Install/setup.sh
@@ -212,6 +212,7 @@ while true; do
             else #avsrun present
                 if grep "offline_demo" $AUTOSTART ; then #offline_demo present
                     # Remove startup script from autostart file
+                    echo "Warning: Not adding avsrun in autostart since offline demo is already present. Start AVS by following instructions on offline_demo startup"
                     sed -i '/'"$AUTOSTART_SESSION"'/d' $AUTOSTART
                 fi
             fi

--- a/tools/Install/setup.sh
+++ b/tools/Install/setup.sh
@@ -204,9 +204,16 @@ while true; do
             break;;
         y|Y|yes|YES )
             grep $AUTOSTART_SESSION $AUTOSTART > /dev/null 2>&1
-            if [ $? != 0 ]; then
-                # Append startup script if not already in autostart file
-                echo "@lxterminal -t $AUTOSTART_SESSION --geometry=150x50 -e $STARTUP_SCRIPT" >> $AUTOSTART
+            if [ $? != 0 ]; then #avsrun not present
+                if ! grep "offline_demo" $AUTOSTART ; then #offline_demo not present
+                    # Append startup script if not already in autostart file
+                    echo "@lxterminal -t $AUTOSTART_SESSION --geometry=150x50 -e $STARTUP_SCRIPT" >> $AUTOSTART
+                fi
+            else #avsrun present
+                if grep "offline_demo" $AUTOSTART ; then #offline_demo present
+                    # Remove startup script from autostart file
+                    sed -i '/'"$AUTOSTART_SESSION"'/d' $AUTOSTART
+                fi
             fi
             break;;
     esac


### PR DESCRIPTION
Reasoning behind these changes:
If offline demo has already been installed in the Pi, it will run a startup script that will give options of avsrun or offline_demo based on a button press. So even when the user says yes to starting avs on startup, we do not add avsrun in the startup since it is going to happen through the offline demo startup procedure.