### PR TITLE
Add new autostart script and other changes

### DIFF
--- a/tools/Install/.avsrun-startup.sh
+++ b/tools/Install/.avsrun-startup.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+CONFIG_JSON_FILE="/home/pi/sdk-folder/sdk-build/Integration/AlexaClientSDKConfig.json"
+if [ -f $CONFIG_JSON_FILE ]; then
+    /home/pi/sdk-folder/sdk-build/SampleApp/src/SampleApp $CONFIG_JSON_FILE /home/pi/sdk-folder/third-party/alexa-rpi/models
+else
+    echo "AVS setup is not completed, follow the steps below:"
+    echo ""
+    echo ""
+    echo "1. Register Alexa with AVS and save a *config.json* file by following https://github.com/alexa/avs-device-sdk/wiki/Create-Security-Profile."
+    echo ""
+    echo ""
+    echo "2. Copy the *config.json* into the directory \`vocalfusion_3510_avs_setup\`"
+    echo ""
+    echo ""
+    echo "3. Go to the directory \`vocalfusion_3510_avs_setup\` and type:"
+    echo "    \`avssetup config.json\`"
+    echo ""
+    echo ""
+    echo "4. Read and accept the Sensory and the AVS Device SDK license agreements."
+    echo ""
+    echo ""
+    echo "5. Complete the setup by following the steps from 8 onward here: https://github.com/xmos/vocalfusion_3510_avs_setup"
+    echo ""
+    echo ""
+fi
+$SHELL

--- a/tools/Install/.avsrun-startup.sh
+++ b/tools/Install/.avsrun-startup.sh
@@ -3,7 +3,7 @@ CONFIG_JSON_FILE="/home/pi/sdk-folder/sdk-build/Integration/AlexaClientSDKConfig
 if [ -f $CONFIG_JSON_FILE ]; then
     /home/pi/sdk-folder/sdk-build/SampleApp/src/SampleApp $CONFIG_JSON_FILE /home/pi/sdk-folder/third-party/alexa-rpi/models
 else
-    echo "AVS setup is not completed, follow the steps below:"
+    echo "AVS setup is not complete, follow the steps below:"
     echo ""
     echo ""
     echo "1. Register Alexa with AVS and save a *config.json* file by following https://github.com/alexa/avs-device-sdk/wiki/Create-Security-Profile."

--- a/tools/Install/setup.sh
+++ b/tools/Install/setup.sh
@@ -358,7 +358,7 @@ cat << EOF > "$OUTPUT_CONFIG_FILE"
 EOF
 
 cd $CURRENT_DIR
-bash genConfig.sh config.json $DEVICE_SERIAL_NUMBER $CONFIG_DB_PATH $SOURCE_PATH/avs-device-sdk $TEMP_CONFIG_FILE
+bash genConfig.sh $CONFIG_JSON_FILE $DEVICE_SERIAL_NUMBER $CONFIG_DB_PATH $SOURCE_PATH/avs-device-sdk $TEMP_CONFIG_FILE
 
 # Delete first line from temp file to remove opening bracket
 sed -i -e "1d" $TEMP_CONFIG_FILE
@@ -404,7 +404,7 @@ echo "avssetup() { f=\$(eval readlink -f \"\$1\"); bash /home/pi/vocalfusion_351
 echo "echo "Available AVS aliases:"" >> $ALIASES
 echo "echo -e "avsrun, avsunit, avssetup"" >> $ALIASES
 echo "echo "If authentication fails, please check $BUILD_PATH/Integration/AlexaClientSDKConfig.json"" >> $ALIASES
-echo "echo "Remove .bash_aliases and open a new terminal to remove bindings"" >> $ALIASES
+echo "echo "To re-configure the AVS device SDK, please run avssetup with the appropriate JSON config file"" >> $ALIASES
 
 echo " **** Completed Configuration/Build ***"
 popd > /dev/null

--- a/tools/Install/setup.sh
+++ b/tools/Install/setup.sh
@@ -242,8 +242,8 @@ if [ ! -f $AUTOSTART ]; then
     cp /etc/xdg/lxsession/LXDE-pi/autostart $AUTOSTART
 fi
 STARTUP_SCRIPT=$CURRENT_DIR/.avsrun-startup.sh
-# copy script from avs-device-sdk
-cp $INSTALL_BASE/avs-device-sdk/tools/Install/.avsrun-startup.sh .
+# copy startup script from avs-device-sdk
+cp $INSTALL_BASE/avs-device-sdk/tools/Install/.avsrun-startup.sh $CURRENT_DIR
 chmod a+rx $STARTUP_SCRIPT
 
 while true; do

--- a/tools/Install/setup.sh
+++ b/tools/Install/setup.sh
@@ -30,8 +30,6 @@ PORT_AUDIO_DOWNLOAD_URL="http://www.portaudio.com/archives/$PORT_AUDIO_FILE"
 
 BUILD_TESTS=${BUILD_TESTS:-'true'}
 
-pushd $( pwd )
-
 pushd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null
 CURRENT_DIR="$( pwd )"
 THIS_SCRIPT="$CURRENT_DIR/setup.sh"
@@ -400,11 +398,10 @@ sed -i '/Remove/d' $ALIASES > /dev/null
 
 echo "alias avsrun=\"$BUILD_PATH/SampleApp/src/SampleApp $OUTPUT_CONFIG_FILE $THIRD_PARTY_PATH/alexa-rpi/models\"" >> $ALIASES
 echo "alias avsunit=\"bash $TEST_SCRIPT\"" >> $ALIASES
-echo "avssetup() { f=\$(eval readlink -f \"\$1\"); bash /home/pi/$CURRENT_DIR/setup.sh \$f; }" >> $ALIASES
+echo "avssetup() { f=\$(eval readlink -f \"\$1\"); bash $CURRENT_DIR/setup.sh \$f; }" >> $ALIASES
 echo "echo "Available AVS aliases:"" >> $ALIASES
 echo "echo -e "avsrun, avsunit, avssetup"" >> $ALIASES
 echo "echo "If authentication fails, please check $BUILD_PATH/Integration/AlexaClientSDKConfig.json"" >> $ALIASES
 echo "echo "To re-configure the AVS device SDK, please run avssetup with the appropriate JSON config file"" >> $ALIASES
 
 echo " **** Completed Configuration/Build ***"
-popd > /dev/null

--- a/tools/Install/setup.sh
+++ b/tools/Install/setup.sh
@@ -28,8 +28,9 @@ CLONE_URL=${CLONE_URL:- 'git://github.com/xmos/avs-device-sdk.git'}
 PORT_AUDIO_FILE="pa_stable_v190600_20161030.tgz"
 PORT_AUDIO_DOWNLOAD_URL="http://www.portaudio.com/archives/$PORT_AUDIO_FILE"
 
-
 BUILD_TESTS=${BUILD_TESTS:-'true'}
+
+pushd $( pwd )
 
 pushd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null
 CURRENT_DIR="$( pwd )"
@@ -170,7 +171,7 @@ PLATFORM=${PLATFORM:-$(get_platform)}
 
 if [ "$PLATFORM" == "Raspberry pi" ]
 then
-  source pi.sh
+  source $CURRENT_DIR/pi.sh
 elif [ "$PLATFORM" == "Windows mingw64" ]
 then
   source mingw.sh
@@ -399,11 +400,11 @@ sed -i '/Remove/d' $ALIASES > /dev/null
 
 echo "alias avsrun=\"$BUILD_PATH/SampleApp/src/SampleApp $OUTPUT_CONFIG_FILE $THIRD_PARTY_PATH/alexa-rpi/models\"" >> $ALIASES
 echo "alias avsunit=\"bash $TEST_SCRIPT\"" >> $ALIASES
-echo "avssetup() { f=\$(eval readlink -f \"\$1\"); cd /home/pi/vocalfusion_3510_avs_setup; bash setup.sh \$f; }" >> $ALIASES
+echo "avssetup() { f=\$(eval readlink -f \"\$1\"); bash /home/pi/vocalfusion_3510_avs_setup/setup.sh \$f; }" >> $ALIASES
 echo "echo "Available AVS aliases:"" >> $ALIASES
 echo "echo -e "avsrun, avsunit, avssetup"" >> $ALIASES
 echo "echo "If authentication fails, please check $BUILD_PATH/Integration/AlexaClientSDKConfig.json"" >> $ALIASES
 echo "echo "Remove .bash_aliases and open a new terminal to remove bindings"" >> $ALIASES
 
 echo " **** Completed Configuration/Build ***"
-
+popd > /dev/null

--- a/tools/Install/setup.sh
+++ b/tools/Install/setup.sh
@@ -64,6 +64,9 @@ ALIASES="$HOME/.bash_aliases"
 # Default value for XMOS device
 XMOS_DEVICE="xvf3510"
 
+# Default value for AVS SDK version tag
+AVS_SDK_VERSION_TAG="master"
+
 # Default device serial number if nothing is specified
 DEVICE_SERIAL_NUMBER="123456"
 
@@ -105,18 +108,18 @@ get_platform() {
 show_help() {
   echo  'Usage: setup.sh <config-json-file> <xmos-tag> [OPTIONS]'
   echo  'The <config-json-file> can be downloaded from developer portal and must contain the following:'
-  echo  '   "clientId": "<OAuth client ID>"'
+  echo  '   "clientId": "<Auth client ID>"'
   echo  '   "productId": "<your product name for device>"'
-  echo  ' The  <xmos-tag> is the tag in the GIT repository xmos/avs-device-sdk'
   echo  ''
   echo  'Optional parameters'
-  echo  '  -s <serial-number>    If nothing is provided, the default device serial number is 123456'
-  echo  '  -a <file-name>        The file that contains Android installation configurations (e.g. androidConfig.txt)'
-  echo  '  -d <xmos-device-type> XMOS device to setup: default xvf3510, possible value xvf3500'
-  echo  '  -h                    Display this help and exit'
+  echo  '  -t <avs-sdk-version-tag> The tag in the GIT repository xmos/avs-device-sdk'
+  echo  '  -s <serial-number>       If nothing is provided, the default device serial number is 123456'
+  echo  '  -a <file-name>           The file that contains Android installation configurations (e.g. androidConfig.txt)'
+  echo  '  -d <xmos-device-type>    XMOS device to setup: default xvf3510, possible value xvf3500'
+  echo  '  -h                       Display this help and exit'
 }
 
-if [[ $# -lt 2 ]]; then
+if [[ $# -lt 1 ]]; then
     show_help
     exit 1
 fi
@@ -128,13 +131,14 @@ if [ ! -f "$CONFIG_JSON_FILE" ]; then
     exit 1
 fi
 
-XMOS_TAG=$2
 
 shift 1
 
-OPTIONS=s:a:d:h
+OPTIONS=t:s:a:d:h
 while getopts "$OPTIONS" opt ; do
     case $opt in
+        t ) AVS_SDK_VERSION_TAG="$OPTARG"
+            ;;
         s )
             DEVICE_SERIAL_NUMBER="$OPTARG"
             ;;
@@ -228,7 +232,7 @@ echo "==============> CREATING AUTOSTART SCRIPT ============"
 echo
 
 
-# Create autostart script
+# Set up autostart script
 AUTOSTART_SESSION="avsrun"
 AUTOSTART_DIR=$HOME/.config/lxsession/LXDE-pi
 AUTOSTART=$AUTOSTART_DIR/autostart
@@ -237,12 +241,10 @@ if [ ! -f $AUTOSTART ]; then
     cp /etc/xdg/lxsession/LXDE-pi/autostart $AUTOSTART
 fi
 STARTUP_SCRIPT=$CURRENT_DIR/.avsrun-startup.sh
-cat << EOF > "$STARTUP_SCRIPT"
-#!/bin/bash
-$BUILD_PATH/SampleApp/src/SampleApp $OUTPUT_CONFIG_FILE $THIRD_PARTY_PATH/alexa-rpi/models
-\$SHELL
-EOF
+# copy script from avs-device-sdk
+cp $UILD_FOLDER/avs-device-sdk/tools/Install/.avsrun-startup.sh
 chmod a+rx $STARTUP_SCRIPT
+
 while true; do
     read -p "Automatically run AVS SDK at startup (y/n)? " ANSWER
     case ${ANSWER} in
@@ -307,7 +309,7 @@ then
     echo
 
     cd $SOURCE_PATH
-    git clone -b $XMOS_TAG $CLONE_URL
+    git clone -b $AVS_SDK_VERSION_TAG $CLONE_URL
     if [ $XMOS_DEVICE = "xvf3510" ]
     then
       echo
@@ -337,6 +339,7 @@ then
   make SampleApp -j2
 
 else
+  build_kwd_engine
   cd $BUILD_PATH
   make SampleApp -j2
 fi

--- a/tools/Install/setup.sh
+++ b/tools/Install/setup.sh
@@ -112,7 +112,7 @@ show_help() {
   echo  '   "clientId": "<Auth client ID>"'
   echo  '   "productId": "<your product name for device>"'
   echo  ''
-  echo  'Optio/nal parameters'
+  echo  'Optional parameters'
   echo  '  -t <avs-sdk-version-tag> The tag in the GIT repository xmos/avs-device-sdk, default is 'master''
   echo  '  -s <serial-number>       If nothing is provided, the default device serial number is 123456'
   echo  '  -a <file-name>           The file that contains Android installation configurations (e.g. androidConfig.txt)'
@@ -400,7 +400,7 @@ sed -i '/Remove/d' $ALIASES > /dev/null
 
 echo "alias avsrun=\"$BUILD_PATH/SampleApp/src/SampleApp $OUTPUT_CONFIG_FILE $THIRD_PARTY_PATH/alexa-rpi/models\"" >> $ALIASES
 echo "alias avsunit=\"bash $TEST_SCRIPT\"" >> $ALIASES
-echo "avssetup() { f=\$(eval readlink -f \"\$1\"); bash /home/pi/vocalfusion_3510_avs_setup/setup.sh \$f; }" >> $ALIASES
+echo "avssetup() { f=\$(eval readlink -f \"\$1\"); bash /home/pi/$CURRENT_DIR/setup.sh \$f; }" >> $ALIASES
 echo "echo "Available AVS aliases:"" >> $ALIASES
 echo "echo -e "avsrun, avsunit, avssetup"" >> $ALIASES
 echo "echo "If authentication fails, please check $BUILD_PATH/Integration/AlexaClientSDKConfig.json"" >> $ALIASES

--- a/tools/Install/setup.sh
+++ b/tools/Install/setup.sh
@@ -111,7 +111,7 @@ show_help() {
   echo  '   "clientId": "<Auth client ID>"'
   echo  '   "productId": "<your product name for device>"'
   echo  ''
-  echo  'Optional parameters'
+  echo  'Optio/nal parameters'
   echo  '  -t <avs-sdk-version-tag> The tag in the GIT repository xmos/avs-device-sdk'
   echo  '  -s <serial-number>       If nothing is provided, the default device serial number is 123456'
   echo  '  -a <file-name>           The file that contains Android installation configurations (e.g. androidConfig.txt)'
@@ -242,7 +242,7 @@ if [ ! -f $AUTOSTART ]; then
 fi
 STARTUP_SCRIPT=$CURRENT_DIR/.avsrun-startup.sh
 # copy script from avs-device-sdk
-cp $UILD_FOLDER/avs-device-sdk/tools/Install/.avsrun-startup.sh
+cp $INSTALL_BASE/avs-device-sdk/tools/Install/.avsrun-startup.sh .
 chmod a+rx $STARTUP_SCRIPT
 
 while true; do

--- a/tools/Install/setup.sh
+++ b/tools/Install/setup.sh
@@ -399,9 +399,9 @@ sed -i '/Remove/d' $ALIASES > /dev/null
 
 echo "alias avsrun=\"$BUILD_PATH/SampleApp/src/SampleApp $OUTPUT_CONFIG_FILE $THIRD_PARTY_PATH/alexa-rpi/models\"" >> $ALIASES
 echo "alias avsunit=\"bash $TEST_SCRIPT\"" >> $ALIASES
-echo "alias avssetup=\"cd $CURRENT_DIR; bash setup.sh\"" >> $ALIASES
+echo "avssetup() { f=\$(eval readlink -f \"\$1\"); cd /home/pi/vocalfusion_3510_avs_setup; bash setup.sh \$f; }" >> $ALIASES
 echo "echo "Available AVS aliases:"" >> $ALIASES
-echo "echo -e "avsrun, avsunit, avssetup, avsauth"" >> $ALIASES
+echo "echo -e "avsrun, avsunit, avssetup"" >> $ALIASES
 echo "echo "If authentication fails, please check $BUILD_PATH/Integration/AlexaClientSDKConfig.json"" >> $ALIASES
 echo "echo "Remove .bash_aliases and open a new terminal to remove bindings"" >> $ALIASES
 

--- a/tools/Install/setup.sh
+++ b/tools/Install/setup.sh
@@ -113,7 +113,7 @@ show_help() {
   echo  '   "productId": "<your product name for device>"'
   echo  ''
   echo  'Optio/nal parameters'
-  echo  '  -t <avs-sdk-version-tag> The tag in the GIT repository xmos/avs-device-sdk'
+  echo  '  -t <avs-sdk-version-tag> The tag in the GIT repository xmos/avs-device-sdk, default is 'master''
   echo  '  -s <serial-number>       If nothing is provided, the default device serial number is 123456'
   echo  '  -a <file-name>           The file that contains Android installation configurations (e.g. androidConfig.txt)'
   echo  '  -d <xmos-device-type>    XMOS device to setup: default xvf3510, possible value xvf3500'


### PR DESCRIPTION
- check at startup if  AlexaClientSDKConfig is present
- move autostart script to a separate file
- set AVS_SDK_VERSION_TAG as optional parameter, default is 'master'
- refresh Sensory license during avssetup
- improve avssetup so that it can be called with any config.json file from any location