### PR TITLE
Feature/run avs with offline demo

### DIFF
--- a/tools/Install/setup.sh
+++ b/tools/Install/setup.sh
@@ -253,7 +253,7 @@ echo
 AUTOSTART_SESSION="avsrun"
 AUTOSTART_DIR=$HOME/.config/lxsession/LXDE-pi
 AUTOSTART=$AUTOSTART_DIR/autostart
-AVSRUN_CMD="lxterminal -t avsrun -e \"$BUILD_PATH/SampleApp/src/SampleApp $OUTPUT_CONFIG_FILE $THIRD_PARTY_PATH/alexa-rpi/models NONE 12\" &"
+AVSRUN_CMD="lxterminal -t avsrun -e \"$BUILD_PATH/SampleApp/src/SampleApp $OUTPUT_CONFIG_FILE $THIRD_PARTY_PATH/alexa-rpi/models NONE 12 \$*\" &" #$* is for passing any extra arguments to Sampleapp through .avsrun-startup.sh shell script
 STARTUP_SCRIPT=$CURRENT_DIR/.avsrun-startup.sh
 if [ ! -f $AUTOSTART ]; then
     mkdir -p $AUTOSTART_DIR


### PR DESCRIPTION
Changes to run AVS along with sales demo if sales demo is installed on the Pi as well. Some documentation present in https://xmosjira.atlassian.net/wiki/spaces/~701212200/pages/2190147591/Changes+made+to+the+xmos+avs-device-sdk+repo+to+run+sales+demo+alongside+AVS.

This PR needs to be merged along with https://github.com/xmos/vocalfusion_3510_sales_demo/pull/30