### PR TITLE
Delay start of AVS till asoundrc is copied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ Feature enhancements, updates, and resolved issues from all releases are availab
 
 **XMOS-only change** - version 0:
 
-    * ported XMOS KWD adapters to latest version of the SDK
+    * port XMOS KWD adapters to latest version of the SDK
+    * delay startup of AVS console till .asoundrc file is found
 
 ### Version 1.25.0 - August 23 2021
 Feature enhancements, updates, and resolved issues from all releases are available on the [Amazon developer portal](https://developer.amazon.com/docs/alexa/avs-device-sdk/release-notes.html)

--- a/tools/Install/setup.sh
+++ b/tools/Install/setup.sh
@@ -343,15 +343,19 @@ if [ ! -f $AUTOSTART ]; then
   cp /etc/xdg/lxsession/LXDE-pi/autostart $AUTOSTART
 fi
 
+# in the startup script we need to check if the .asoundrc file is present,
+# this is needed because of this known issue in Raspian Buster:
+# https://forums.raspberrypi.com/viewtopic.php?t=295008# 
 ASOUNDRC_FILE="~/.asoundrc"
+PAUSE_SEC=2
 cat << EOF > "$STARTUP_SCRIPT"
 #!/bin/bash
 # wait for host to boot up
 sleep 5
 # check if .asoundrc file exists
 while [[ ! -f $ASOUNDRC_FILE ]]; do
-    sleep 2
-    echo "$ASOUNDRC_FILE file not found, wait 2 second(s)"
+    sleep $PAUSE_SEC
+    echo "$ASOUNDRC_FILE file not found, wait $PAUSE_SEC secons"
 done
 # start AVS console
 $AVSRUN_CMD

--- a/tools/Install/setup.sh
+++ b/tools/Install/setup.sh
@@ -342,8 +342,18 @@ if [ ! -f $AUTOSTART ]; then
   mkdir -p $AUTOSTART_DIR
   cp /etc/xdg/lxsession/LXDE-pi/autostart $AUTOSTART
 fi
+
+ASOUNDRC_FILE="~/.asoundrc"
 cat << EOF > "$STARTUP_SCRIPT"
 #!/bin/bash
+# wait for host to boot up
+sleep 5
+# check if .asoundrc file exists
+while [[ ! -f $ASOUNDRC_FILE ]]; do
+    sleep 2
+    echo "$ASOUNDRC_FILE file not found, wait 2 second(s)"
+done
+# start AVS console
 $AVSRUN_CMD
 EOF
 


### PR DESCRIPTION
This change is needed to support the latest version of Buster, as PulseAudio deletes the .'asoundrc' file at startup

Addresses https://github.com/xmos/vocalfusion-avs-setup/issues/63